### PR TITLE
Add robot state publisher - perception module

### DIFF
--- a/momo_description/launch/robot_state_publisher.launch.py
+++ b/momo_description/launch/robot_state_publisher.launch.py
@@ -1,0 +1,39 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    urdf_file = os.path.join(
+        get_package_share_directory('momo_description'),
+        'urdf',
+        'momo_description.urdf'
+    )
+
+    with open(urdf_file, 'r') as infp:
+        robot_description = infp.read()
+
+    return LaunchDescription([
+        Node(
+            package='robot_state_publisher',
+            executable='robot_state_publisher',
+            name='robot_state_publisher',
+            output='screen',
+            parameters=[{'robot_description': robot_description}],
+        ),
+        Node(
+            package='joint_state_publisher',
+            executable='joint_state_publisher',
+            name='joint_state_publisher',
+            output='screen',
+            parameters=[{'use_gui': True}],
+        ),
+        Node(
+            package='joint_state_publisher_gui',
+            executable='joint_state_publisher_gui',
+            name='joint_state_publisher_gui',
+            output='screen',
+        ),
+    ])


### PR DESCRIPTION
To visualise MoMo urdf with perception module in rviz:

`ros2 launch momo_description robot_state_publisher.launch.py`


![image](https://github.com/user-attachments/assets/39b96e62-d06b-4caa-812c-5fc999bb2767)
